### PR TITLE
Reenable native voting using ENS tokens voting power

### DIFF
--- a/src/components/VoteModal.tsx
+++ b/src/components/VoteModal.tsx
@@ -92,27 +92,6 @@ function VoteModal({ open, onClose, grantIds, proposalId, address }: VoteModalPr
 
   const votingPower = snapshotProposal?.votesAvailable ?? 0;
 
-  const { data: balanceOf } = useContractRead({
-    address: '0xfb03372a30E173A8998f732dDfeA0138144B468e',
-    abi: [
-      {
-        inputs: [
-          { internalType: 'address', name: 'account', type: 'address' },
-          { internalType: 'uint256', name: 'id', type: 'uint256' },
-        ],
-        name: 'balanceOf',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    ] as const,
-    functionName: 'balanceOf',
-    args: [address as Address, 1n],
-    chainId: 10,
-  });
-
-  const hasVoterCard = balanceOf && balanceOf > 0n;
-
   return (
     <Dialog open={open} onDismiss={handleDismiss} variant="blank">
       <Dialog.CloseButton onClick={handleDismiss} />
@@ -148,11 +127,6 @@ function VoteModal({ open, onClose, grantIds, proposalId, address }: VoteModalPr
           <DisplayItem label={`Selected proposal${grantIds.length > 1 ? 's' : ''}`} value={grantIds.join(', ')} />
         </DisplayItems>
 
-        {votingPower === 0 && !!hasVoterCard && (
-          <Helper type="warning">
-            You should have voting power but there seems to be an error with Snapshot. Try again later.
-          </Helper>
-        )}
       </InnerModal>
       <Dialog.Footer
         leading={

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -129,7 +129,7 @@ const content: Content[] = [
       {
         question: 'Understanding the Voting Process',
         answer:
-          'In Rounds 1 through 9, voters participated using ENS Governance Tokens where 1 $ENS token = 1 vote. In Round 10, voting is following a Voter Card system. See more in the Voter Card section below.',
+          'In Rounds 1 through 9, voters participated using ENS Governance Tokens where 1 $ENS token = 1 vote. In Round 10 and 11, voting was following a Voter Card system. See more in the Voter Card section below. In Round 12, we are getting back to ENS Governance Tokens voting, where 1 $ENS token = 1 vote',
       },
       {
         question: 'Are proposals submitted onchain?',


### PR DESCRIPTION
This PR reverts the repo to commit 20e4301b54bbd67092ce2a717173e656074fdf03 (Nov 28, 2023) due to an issue that arose after the December 1st commits.

The native voting experience at the website stopped working after enabling the voter-card voting system.
 
This change re-enables native voting directly from the ENS small grants website, like it was before, and removes unnecessary checks related to the old voting card system.