### PR TITLE
change voterChoices array for ens voting power method

### DIFF
--- a/src/hooks/useSnapshotProposal.ts
+++ b/src/hooks/useSnapshotProposal.ts
@@ -116,8 +116,12 @@ export function useSnapshotProposal(proposalId: string) {
         voteSamples: body.data.votes
           // Only show the voters who voted for this grant
           .filter(vote => {
-            // the keys are the choiceIds which are always numbers, but javascript's Object.keys always returns string so we need to cast it
-            const voterChoices = Object.keys(vote.choice).map(choice => Number(choice));
+            // // the keys are the choiceIds which are always numbers, but javascript's Object.keys always returns string so we need to cast it
+            // const voterChoices = Object.keys(vote.choice).map(choice => Number(choice));
+
+            // For ens voting power method, the vote.choice is an array of numbers (this can change depending on the voting method)
+            const voterChoices = vote.choice as number[];
+
             return voterChoices.includes(i + 1);
           })
           .sort((a, b) => {


### PR DESCRIPTION
This PR Fixes #23

The problem arose after changing the voting method from approval to ens voting power, where the type of the vote.choices object retrieved by the Snapshot API changed. Specifically, the API now returns a different data structure, causing the voterChoices array to be built incorrectly and breaking the code.

This fix changes the way the voterChoices array is built to accommodate the new data structure. The code now correctly populates the array with the expected values and the frontend is working accordingly.