### PR TITLE
Fix Voting Bug in Grant Page

### DIFF
--- a/src/components/GrantProposalCard.tsx
+++ b/src/components/GrantProposalCard.tsx
@@ -279,7 +279,7 @@ function GrantProposalCard({
                   // if target is checked, push the proposal id to the array
                   if (e.target.checked) {
                     // Clear session storage and refresh page if the Snapshot ID is not available
-                    if (!proposal.snapshot?.choiceId && proposal.snapshot?.choiceId !== 0) {
+                    if (proposal.snapshot?.choiceId === undefined) {
                       removeItem(`round-${round.id}-grants`, 'session');
                       window.location.reload();
                     }

--- a/src/components/VoteSection.tsx
+++ b/src/components/VoteSection.tsx
@@ -171,14 +171,14 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
               onChange={e => {
                 // if target is checked, push the proposal id to the array
                 if (e.target.checked) {
-                  if (!proposal.snapshot?.choiceId) return alert('Proposal choice id not found');
+                  if (proposal.snapshot?.choiceId === undefined) return alert('Proposal choice id not found');
 
                   setSelectedProps({
                     round: Number(round.id),
                     votes: [...(selectedProps.votes || []), proposal.snapshot.choiceId],
                   });
                 } else {
-                  if (!proposal.snapshot?.choiceId) return alert('Proposal choice id not found');
+                  if (proposal.snapshot?.choiceId === undefined) return alert('Proposal choice id not found');
 
                   // if target is unchecked, remove the proposal id from the array
                   setSelectedProps({
@@ -194,7 +194,7 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
         {address && selectedProps.votes.length > 0 && (
           <Button
             variant={selectedProps.votes.includes(proposal.snapshot?.choiceId || 0) ? 'primary' : 'secondary'}
-            disabled={!proposal.snapshot?.choiceId || votingOver}
+            disabled={proposal.snapshot?.choiceId === undefined || votingOver}
             size="small"
             onClick={() => setVotingModalOpen(true)}
           >

--- a/src/components/VoteSection.tsx
+++ b/src/components/VoteSection.tsx
@@ -150,7 +150,6 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
     return <Typography>Voting has not started</Typography>;
   }
 
-  console.log(" selectedProps.votes.includes(proposal.snapshot?.choiceId!)", selectedProps.votes.includes(proposal.snapshot?.choiceId!) )
   return (
     <>
       <Container>

--- a/src/components/VoteSection.tsx
+++ b/src/components/VoteSection.tsx
@@ -150,6 +150,7 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
     return <Typography>Voting has not started</Typography>;
   }
 
+  console.log(" selectedProps.votes.includes(proposal.snapshot?.choiceId!)", selectedProps.votes.includes(proposal.snapshot?.choiceId!) )
   return (
     <>
       <Container>
@@ -166,7 +167,7 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
               label=""
               variant="regular"
               checked={
-                proposal.snapshot?.choiceId ? selectedProps.votes.includes(proposal.snapshot.choiceId) : undefined
+                proposal.snapshot?.choiceId !== undefined ? selectedProps.votes.includes(proposal.snapshot.choiceId) : undefined
               }
               onChange={e => {
                 // if target is checked, push the proposal id to the array
@@ -194,7 +195,7 @@ function VoteInProgressSection({ round, snapshotProposalId, proposal }: VoteInPr
         {address && selectedProps.votes.length > 0 && (
           <Button
             variant={selectedProps.votes.includes(proposal.snapshot?.choiceId || 0) ? 'primary' : 'secondary'}
-            disabled={proposal.snapshot?.choiceId === undefined || votingOver}
+            disabled={!selectedProps.votes.includes(proposal.snapshot?.choiceId!) || votingOver}
             size="small"
             onClick={() => setVotingModalOpen(true)}
           >


### PR DESCRIPTION
This PR addresses two key issues related to the voting functionality on the grant page of our application.

Here is a screenshot demonstrating the issue:

<img alt="Screenshot" src="https://github.com/ensdao/ens-small-grants/assets/96581579/d536e376-c3bc-4311-a962-00e622d65af2.png">

Firstly, we identified a bug where voting for the first grant in a round from the grant page is not functioning as expected. This was due to an incorrect check for falsy values using the nullish operator. The operator was treating a choiceId value of 0 as false, when in fact the correct check should have been for an undefined value.

Secondly, there is a minor bug where if a grant was selected for voting on the round page, and then voted on directly from the grant page, the values would get duplicated. This could potentially cause errors when sending the votes through the Snapshot SDK.

To resolve these issues, we have made the following changes:

1. Adjusted the default checkbox value for the voting section checkbox on the grant page.
2. Fixed the nullish operator checks changing it to checks for undefined values.

These changes ensure a smoother and more accurate voting process on the grant page, and clear the session storage properly, enhancing the overall user experience.